### PR TITLE
Add README, support startDate when create a new task

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,24 @@ DIDA is a powerful to-do & task management app with seamless cloud synchronizati
 This plugin integrates with [DIDA](https://dida365.com), allowing you to easily transform and sync data between DIDA and Obsidian.
 
 ## Build
+```shell
+git clone git@github.com:how2051/dida-obsidian.git
 cd dida-obsidian
 npm install
 npm run dev
+```
 
 ## Manually install
-copy `main.js`, `manifest.json`, `styles.css` to your .obsidian/plugins
+copy `main.js`, `manifest.json`, `styles.css` to your `.obsidian/plugins`
 
 
 ## Usage
-
 To use the plugin, you should first log into DIDA via the plugin settings. Once that’s done, you can access the commands as needed.
 
 ## Features
-
--   Create task
+you can bind the commands to hotkeys you like
+- Create task: select some text and create a task
+- Complete task: select the same text and complete the task
 
 ## Dev Info
-
 Make sure your NodeJS is at least v16 (`node --version`)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ DIDA is a powerful to-do & task management app with seamless cloud synchronizati
 
 This plugin integrates with [DIDA](https://dida365.com), allowing you to easily transform and sync data between DIDA and Obsidian.
 
+## Build
+cd dida-obsidian
+npm install
+npm run dev
+
+## Manually install
+copy `main.js`, `manifest.json`, `styles.css` to your .obsidian/plugins
+
+
 ## Usage
 
 To use the plugin, you should first log into DIDA via the plugin settings. Once that’s done, you can access the commands as needed.

--- a/main.ts
+++ b/main.ts
@@ -36,6 +36,9 @@ type Task = {
 	content: string;
 	priority: number;
 	//  0 | 1 | 3 | 5
+	isAllDay: boolean;
+	startDate: string;
+	dueDate: string;
 	projectId: string;
 	status: number;
 	sortOrder: number;
@@ -281,17 +284,23 @@ class CreateTaskModal extends Modal {
 		content: Task["content"];
 		priority: Task["priority"];
 		projectId: Task["projectId"];
+		isAllDay: Task["isAllDay"];
+		startDate: Task["startDate"];
+		dueDate: Task["dueDate"];
 	};
 
 	constructor(app: App, plugin: TickTickPlugin, taskData: Partial<Task>) {
 		super(app);
 		this.plugin = plugin;
-		const { title, content, priority, projectId } = taskData;
+		const { title, content, priority, projectId, isAllDay, startDate, dueDate } = taskData;
 		this.taskData = {
 			title: title || "",
 			content: content || "",
 			priority: priority == null ? 0 : priority,
 			projectId: projectId || "inbox",
+			isAllDay: true,
+			startDate: startDate || "Inbox",
+			dueDate: dueDate || "",
 		};
 	}
 
@@ -342,6 +351,32 @@ class CreateTaskModal extends Modal {
 				this.taskData.projectId = value;
 			});
 		projectComp.selectEl.style.flex = "auto";
+
+		// startDateLine
+		const startDateLine = contentEl.createDiv({ cls: "modal-line" });
+		startDateLine.createEl("div", { cls: "label", text: "startDate" });
+		const startDateComp = new DropdownComponent(startDateLine)
+			.addOptions({
+				"Inbox": "None",
+				"Today": "Today",
+				"Tomorrow": "Tomorrow",
+			})
+			.setValue(this.taskData.startDate.toString())
+			.onChange((value) => {
+				if (value === 'None') {	//Inbox
+					this.taskData.startDate = ""
+				} else if (value === 'Today') {	//set startDate to now
+					const currentISODate = new Date().toISOString();
+					this.taskData.startDate = currentISODate.replace("Z", "+0000");
+				} else if (value === 'Tomorrow') {	//set startDate to tomorrow
+					const today = new Date();
+					const tomorrow = new Date(Date());
+					tomorrow.setDate(today.getDate() + 1);
+					const tomorrowISODate = tomorrow.toISOString();
+					this.taskData.startDate = tomorrowISODate.replace("Z", "+0000");
+				}
+			});
+			startDateComp.selectEl.style.flex = "auto";
 
 		// priority
 		const priorityLine = contentEl.createDiv({ cls: "modal-line" });

--- a/main.ts
+++ b/main.ts
@@ -399,6 +399,21 @@ class CreateTaskModal extends Modal {
 			});
 		projectComp.selectEl.style.flex = "auto";
 
+		const handleStartDateChange = (value: string) => {
+			if (value === 'None') {	//Inbox
+				this.taskData.startDate = "";
+			} else if (value === 'Today') {	//set startDate to now
+				const currentISODate = new Date().toISOString();
+				this.taskData.startDate = currentISODate.replace("Z", "+0000");
+			} else if (value === 'Tomorrow') {	//set startDate to tomorrow
+				const today = new Date();
+				const tomorrow = new Date(Date());
+				tomorrow.setDate(today.getDate() + 1);
+				const tomorrowISODate = tomorrow.toISOString();
+				this.taskData.startDate = tomorrowISODate.replace("Z", "+0000");
+			}
+		};
+
 		// startDateLine
 		const startDateLine = contentEl.createDiv({ cls: "modal-line" });
 		startDateLine.createEl("div", { cls: "label", text: "startDate" });
@@ -409,21 +424,11 @@ class CreateTaskModal extends Modal {
 				"Tomorrow": "Tomorrow",
 			})
 			.setValue(this.taskData.startDate.toString())
-			.onChange((value) => {	// this logic will only be triggered when DropdownComponent change
-				if (value === 'None') {	//Inbox
-					this.taskData.startDate = ""
-				} else if (value === 'Today') {	//set startDate to now
-					const currentISODate = new Date().toISOString();
-					this.taskData.startDate = currentISODate.replace("Z", "+0000");
-				} else if (value === 'Tomorrow') {	//set startDate to tomorrow
-					const today = new Date();
-					const tomorrow = new Date(Date());
-					tomorrow.setDate(today.getDate() + 1);
-					const tomorrowISODate = tomorrow.toISOString();
-					this.taskData.startDate = tomorrowISODate.replace("Z", "+0000");
-				}
-			});	// as a result, if I dont change the DropdownComponent, we wont run the default logic
+			.onChange((value) => {
+				handleStartDateChange(value);
+			});
 			startDateComp.selectEl.style.flex = "auto";
+			handleStartDateChange(startDateComp.getValue());	// manually trigger it at first
 
 		// priority
 		const priorityLine = contentEl.createDiv({ cls: "modal-line" });

--- a/main.ts
+++ b/main.ts
@@ -409,7 +409,7 @@ class CreateTaskModal extends Modal {
 				"Tomorrow": "Tomorrow",
 			})
 			.setValue(this.taskData.startDate.toString())
-			.onChange((value) => {
+			.onChange((value) => {	// this logic will only be triggered when DropdownComponent change
 				if (value === 'None') {	//Inbox
 					this.taskData.startDate = ""
 				} else if (value === 'Today') {	//set startDate to now
@@ -422,7 +422,7 @@ class CreateTaskModal extends Modal {
 					const tomorrowISODate = tomorrow.toISOString();
 					this.taskData.startDate = tomorrowISODate.replace("Z", "+0000");
 				}
-			});
+			});	// as a result, if I dont change the DropdownComponent, we wont run the default logic
 			startDateComp.selectEl.style.flex = "auto";
 
 		// priority

--- a/main.ts
+++ b/main.ts
@@ -346,7 +346,7 @@ class CreateTaskModal extends Modal {
 			priority: priority == null ? 0 : priority,
 			projectId: projectId || "inbox",
 			isAllDay: true,
-			startDate: startDate || "Inbox",
+			startDate: startDate || "Today",
 			dueDate: dueDate || "",
 		};
 	}


### PR DESCRIPTION
更新README，设置任务的起始日期。

仿造滴答清单APP端的逻辑，新建任务时可设置任务的起始日期。这里为了和你原有代码逻辑保持一致，默认还是创建为无日期的task到inbox收集箱。（但APP端的逻辑是默认创建为`今日`为起始日期的task）

（这里简单做了`默认`、`今天`、`明天`三个选项，后面再看看要不要加一点点细节）